### PR TITLE
Add windows support for screen sleep inhibitation

### DIFF
--- a/examples/inhibit-suspend/main.rs
+++ b/examples/inhibit-suspend/main.rs
@@ -1,23 +1,30 @@
 use std::time::Duration;
 
-use insomnia::platform;
-use insomnia::{InhibitionManager, LockType};
-use wasmer_enumset::EnumSet;
+use insomnia::{platform, EnumSet, InhibitionManager, LockType};
 
 fn main() -> Result<(), <platform::InhibitionManager as InhibitionManager>::Error> {
     let manager = insomnia::manager()?;
+
     let lock_a = manager.lock(
         EnumSet::only(LockType::AutomaticSuspend),
         "Suspend example",
         "testing automatic suspend inhibition",
     );
     eprintln!("{:?}", &lock_a);
+
     let lock_b = manager.lock(
         LockType::AutomaticSuspend | LockType::ManualSuspend,
         "Suspend example",
         "testing manual suspend inhibition",
     );
     eprintln!("{:?}", &lock_b);
+
+    let lock_c = manager.lock(
+        LockType::Screen.into(),
+        "Suspend example",
+        "testing screen sleep inhibition",
+    );
+    eprintln!("{:?}", &lock_c);
 
     std::thread::sleep(Duration::from_secs(5));
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,10 @@ pub enum LockType {
     /// Manual shutdown
     #[cfg(target_os = "linux")]
     ManualShutdown,
+    // TODO: implement on linux
+    /// Screensaver / Screen sleep
+    #[cfg(target_os = "windows")]
+    Screen,
 }
 
 // TODO: keep a single persistent instance? (probably...)

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -109,9 +109,11 @@ struct PowerRequest(HANDLE);
 
 impl PowerRequest {
     fn new(msg: &str) -> Result<Self, DWORD> {
-        let mut context: REASON_CONTEXT = Default::default();
-        context.Version = winnt::POWER_REQUEST_CONTEXT_VERSION;
-        context.Flags = winnt::POWER_REQUEST_CONTEXT_SIMPLE_STRING;
+        let mut context: REASON_CONTEXT = REASON_CONTEXT {
+            Version: winnt::POWER_REQUEST_CONTEXT_VERSION,
+            Flags: winnt::POWER_REQUEST_CONTEXT_SIMPLE_STRING,
+            ..Default::default()
+        };
 
         // Encode and null-terminate the string as a c-style utf16
         let mut text: Vec<u16> = msg.encode_utf16().chain(iter::once(0)).collect();


### PR DESCRIPTION
This PR is not necessarily meant to be incorporated since it only adds support for windows and not linux as layed out in #1. In my use case, I have been (by no choice of my own) stuck developing on windows and required such a feature as this in my own project. 

This PR also addresses an issue with PowerRequest not null terminating the reason string. (Un)Luckily this has not caused too big of a problem since there tends to be a 0 byte in memory right after the reason string so message is able to be read with just some extra garbage at the end.